### PR TITLE
🐛 fix button label accessibility  bug

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -376,7 +376,7 @@
           <button
             ref=${btnRef}
             onclick=${onClick}
-            aria-describedby=${tooltipId}
+            aria-labelledby=${tooltipId}
           >
             ${icon}
           </button>


### PR DESCRIPTION
Fix button label accessibility bug.

Chrome issues screenshot:
![image](https://user-images.githubusercontent.com/5100938/141703793-75bc0252-feb7-43bb-9364-427eaf4739a5.png)
